### PR TITLE
ipmi-fan-control.spec: Prevent systemd from killing ipmitool immediately on stop

### DIFF
--- a/dist/ipmi-fan-control.spec
+++ b/dist/ipmi-fan-control.spec
@@ -42,6 +42,7 @@ Description=%{_summary}
 [Service]
 ExecStart=%{_bindir}/%{name} -c %{_sysconfdir}/%{name}.toml
 Restart=on-failure
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
ipmi-fan-control needs the ipmitool session to stay open on exit so it
can restore the fan mode.

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>