### PR TITLE
src/main.rs: Do not allow unknown fields in the config file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ struct Zone {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Config {
     ipmitool_args: Option<Vec<String>>,
     zones: Vec<Zone>,


### PR DESCRIPTION
Previously, unknown fields were silently ignored.

Signed-off-by: Andrew Gunnerson <chillermillerlong@hotmail.com>