### PR TITLE
Add support for multiple ipmi sessions

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,5 +1,10 @@
 # Definition of a logical fan zone.
 [[zones]]
+# IPMI session. If unspecified, the `default` session is used, which runs
+# ipmitool with no arguments. Sessions are defined below in the `sessions`
+# section.
+#session = "default"
+
 # List of IPMI zones to be included in this logical zone.
 ipmi_zones = [0]
 
@@ -43,3 +48,17 @@ steps = [
 #    { temp = 30, dcycle = 30 },
 #    { temp = 70, dcycle = 70 },
 #]
+
+# Optional section for defining other ipmitool sessions. This is not needed when
+# connecting to the local machine.
+#
+# The key is the name of the session, which can be any arbitrary non-empty
+# string, and the value is the array of arguments to pass to ipmitool.
+[sessions]
+# Implicit default session for connecting to local IPMI. This runs ipmitool with
+# no arguments. If this is changed, it will take effect in any zone that doesn't
+# explicitly specify another session.
+#"default" = []
+
+# Example of a remote session.
+#"remote" = ["-I", "lanplus", "-H", "<host>", "-U", "<username>", "-P", "<password>"]

--- a/src/ipmi.rs
+++ b/src/ipmi.rs
@@ -1,5 +1,6 @@
 use std::{
     error,
+    ffi::OsStr,
     process::Command,
     result,
 };
@@ -84,10 +85,19 @@ pub struct Ipmi {
 }
 
 impl Ipmi {
-    pub fn new() -> Result<Self> {
+    pub fn with_args<I, S>(args: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
         let mut command = Command::new("ipmitool");
+        command.args(args);
         command.arg("shell");
 
+        Self::with_command(command)
+    }
+
+    fn with_command(command: Command) -> Result<Self> {
         let mut session = PtyReplSession {
             echo_on: false,
             prompt: "ipmitool> ".to_string(),


### PR DESCRIPTION
A session is a single connection to IPMI that can be used for multiple
zones. With this commit, multiple sessions can be defined, allowing a
single ipmi-fan-control instance to manage the fans on multiple servers.

Signed-off-by: Andrew Gunnerson <chillermillerlong@hotmail.com>