### PR TITLE
src/source.rs: Ensure smartctl child process gets waited on

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::{
     io,
     num::ParseIntError,
     path::PathBuf,
+    process::ExitStatus,
     result,
 };
 
@@ -35,6 +36,11 @@ pub enum Error {
     },
     #[snafu(display("No sensors had valid temperature readings"))]
     NoValidReadings,
+    #[snafu(display("Failed to run {:?}: {}", command, status))]
+    CommandError {
+        command: PathBuf,
+        status: ExitStatus,
+    },
     #[snafu(display("IPMI error: {}", source))]
     IpmiError {
         source: ipmi::Error,


### PR DESCRIPTION
I made the bad assumption that `std::process::Child` calls `wait` when
it is dropped, but that is not the case. This commit also adds an
additional check for the exit status of smartctl.

Fixes: #19

Signed-off-by: Andrew Gunnerson <chillermillerlong@hotmail.com>