### PR TITLE
dist/build_source_package.sh: Minor fixes and quality-of-life improvements

### DIFF
--- a/dist/build_source_package.sh
+++ b/dist/build_source_package.sh
@@ -60,13 +60,12 @@ build_tarball() {
     local prefix="ipmi-fan-control-${full_version}"
     tarball="${output_dir}/${prefix}.tar.gz"
 
-    pushd "$(git rev-parse --show-toplevel)"
-    git archive \
+    git -C "$(git rev-parse --show-toplevel)" \
+        archive \
         --format tar.gz \
         --prefix "${prefix}/" \
         --output "${tarball}" \
         HEAD
-    popd
 }
 
 # Build source RPM for Fedora/CentOS

--- a/dist/build_source_package.sh
+++ b/dist/build_source_package.sh
@@ -23,7 +23,7 @@ compute_version() {
 
     IFS='-' read -r -a components <<< "${raw_version}"
 
-    version=${components[0]}
+    version=${components[0]#v}
     plus_rev=${components[1]:-}
     git_commit=${components[2]:-}
     git_commit=${git_commit#g}

--- a/dist/build_source_package.sh
+++ b/dist/build_source_package.sh
@@ -110,14 +110,19 @@ build_pkgbuild() {
 }
 
 clean_up() {
-    rm -r "${temp_dir}"
+    if [[ "${keep_temp_dir}" == true ]]; then
+        echo >&2 "Skipping deletion of temp directory: $(readlink -f "${temp_dir}")"
+    else
+        rm -r "${temp_dir}"
+    fi
 }
 
 help() {
     echo "Usage: ${0} -t <target> [<option>...]"
     echo
     echo 'Options:'
-    echo '  -t, --target  Type of source package to build'
+    echo '  -t, --target         Type of source package to build'
+    echo '  -k, --keep-temp-dir  Do not delete temp directory on exit'
     echo
     echo 'Valid targets:'
     echo '  tarball  - Build a source tarball using "git archive"'
@@ -127,7 +132,7 @@ help() {
 
 parse_args() {
     local args target=
-    if ! args=$(getopt -o ht: -l help,target: -n "${0}" -- "${@}"); then
+    if ! args=$(getopt -o hkt: -l help,keep-temp-dir,target: -n "${0}" -- "${@}"); then
         echo >&2 'Failed to parse arguments'
         help >&2
         exit 1
@@ -135,11 +140,17 @@ parse_args() {
 
     eval set -- "${args}"
 
+    keep_temp_dir=false
+
     while true; do
         case "${1}" in
         -h|--help)
             help
             exit
+            ;;
+        -k|--keep-temp-dir)
+            keep_temp_dir=true
+            shift 1
             ;;
         -t|--target)
             target=${2}

--- a/dist/build_source_package.sh
+++ b/dist/build_source_package.sh
@@ -111,7 +111,7 @@ build_pkgbuild() {
 
 clean_up() {
     if [[ "${keep_temp_dir}" == true ]]; then
-        echo >&2 "Skipping deletion of temp directory: $(readlink -f "${temp_dir}")"
+        echo >&2 "Skipping deletion of temp directory: ${temp_dir}"
     else
         rm -r "${temp_dir}"
     fi
@@ -201,7 +201,7 @@ parse_args "${@}"
 output_dir=$(pwd)/output
 mkdir -p "${output_dir}"
 
-temp_dir=$(mktemp -d -p .)
+temp_dir=$(mktemp -d -p "$(pwd)")
 trap clean_up EXIT
 
 compute_version


### PR DESCRIPTION
* Remove useless pushd/popd output
* Fix leading `v` in version number when `VERSION_OVERRIDE` is not used
* Add `-k`/`--keep-temp-dir` option for easier debugging
* Fix temp dir not being deleted if an error occurs after pushd due to use of relative paths