### PR TITLE
add PKGBUILD support to build_source_package.sh

### DIFF
--- a/dist/build_source_package.sh
+++ b/dist/build_source_package.sh
@@ -95,26 +95,19 @@ build_srpm() {
 build_pkgbuild() {
     check_tools updpkgsums
 
-    mkdir -p "${temp_dir}"/pkg
+    mkdir -p "${temp_dir}"/pkgbuild
     sed \
         -e "s/@VERSION@/${full_version}/g" \
         -e "s/@TARBALL_NAME@/$(basename "${tarball}")/g" \
-        < pkg/PKGBUILD.in \
-        > "${temp_dir}"/pkg/PKGBUILD
+        < pkgbuild/PKGBUILD.in \
+        > "${temp_dir}"/pkgbuild/PKGBUILD
 
-    sed \
-        -e "s/@BINDIR@/\/usr\/bin/g" \
-        -e "s/@SYSCONFDIR@/\/etc/g" \
-        < ipmi-fan-control.service \
-        > "${temp_dir}"/pkg/ipmi-fan-control.service
+    cp "${tarball}" "${temp_dir}"/pkgbuild/
 
+    updpkgsums "${temp_dir}/pkgbuild/PKGBUILD"
 
-    cp "${tarball}" "${temp_dir}"/pkg/
-
-    updpkgsums "${temp_dir}/pkg/PKGBUILD"
-
-    mkdir -p "${output_dir}"/pkg
-    cp -v "${temp_dir}"/pkg/* "${output_dir}"/pkg/
+    mkdir -p "${output_dir}"/pkgbuild
+    cp -v "${temp_dir}"/pkgbuild/* "${output_dir}"/pkgbuild/
 }
 
 clean_up() {

--- a/dist/build_source_package.sh
+++ b/dist/build_source_package.sh
@@ -92,6 +92,31 @@ build_srpm() {
     cp -v "${temp_dir}"/rpm/SRPMS/*.src.rpm "${output_dir}"/rpm/
 }
 
+build_pkgbuild() {
+    check_tools updpkgsums
+
+    mkdir -p "${temp_dir}"/pkg
+    sed \
+        -e "s/@VERSION@/${full_version}/g" \
+        -e "s/@TARBALL_NAME@/$(basename "${tarball}")/g" \
+        < pkg/PKGBUILD.in \
+        > "${temp_dir}"/pkg/PKGBUILD
+
+    sed \
+        -e "s/@BINDIR@/\/usr\/bin/g" \
+        -e "s/@SYSCONFDIR@/\/etc/g" \
+        < ipmi-fan-control.service \
+        > "${temp_dir}"/pkg/ipmi-fan-control.service
+
+
+    cp "${tarball}" "${temp_dir}"/pkg/
+
+    updpkgsums "${temp_dir}/pkg/PKGBUILD"
+
+    mkdir -p "${output_dir}"/pkg
+    cp -v "${temp_dir}"/pkg/* "${output_dir}"/pkg/
+}
+
 clean_up() {
     rm -r "${temp_dir}"
 }
@@ -103,8 +128,9 @@ help() {
     echo '  -t, --target  Type of source package to build'
     echo
     echo 'Valid targets:'
-    echo '  tarball - Build a source tarball using "git archive"'
-    echo '  srpm    - Build an SRPM'
+    echo '  tarball  - Build a source tarball using "git archive"'
+    echo '  srpm     - Build an SRPM'
+    echo '  pkgbuild - Build a PKGBUILD'
 }
 
 parse_args() {
@@ -148,6 +174,9 @@ parse_args() {
         ;;
     srpm)
         actions+=(tarball srpm)
+        ;;
+    pkgbuild)
+        actions+=(tarball pkgbuild)
         ;;
     '')
         echo >&2 "No target specified"

--- a/dist/pkg/PKGBUILD.in
+++ b/dist/pkg/PKGBUILD.in
@@ -1,0 +1,32 @@
+# Maintainer: Christopher Hoage <iam@chrishoage.com>
+
+pkgname=ipmi-fan-control
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="SuperMicro IPMI fan control daemon"
+url="https://github.com/chenxiaolong/$pkgname"
+source=("@TARBALL_NAME@" "ipmi-fan-control.service")
+backup=("etc/$pkgname.toml")
+arch=("x86_64")
+license=("GPLv3+")
+makedepends=("cargo")
+optdepends=("ipmitool" "smartmontools")
+sha256sums=(
+  "dc6fa88529fee2dacfe2b09fdeaa1e392c8a45e9821011231a60e76235a64d77"
+  "84fa667ae48ade2e8276c1abcfeea37428ccfa247544cb82c68f7c472b2897d7"
+)
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  cargo build --release
+}
+
+package() {
+  install -m755 -d "${pkgdir}/usr/lib/systemd/system/"
+  install -Dm644 ipmi-fan-control.service "${pkgdir}/usr/lib/systemd/system/"
+
+  cd "$srcdir/$pkgname-$pkgver"
+  install -Dm755 "target/release/$pkgname" "${pkgdir}/usr/bin/$pkgname"
+  install -Dm 644 config.sample.toml "${pkgdir}/etc/${pkgname}.toml"
+}

--- a/dist/pkgbuild/PKGBUILD.in
+++ b/dist/pkgbuild/PKGBUILD.in
@@ -5,15 +5,15 @@ pkgver=@VERSION@
 pkgrel=1
 pkgdesc="SuperMicro IPMI fan control daemon"
 url="https://github.com/chenxiaolong/$pkgname"
-source=("@TARBALL_NAME@" "ipmi-fan-control.service")
+source=("@TARBALL_NAME@")
 backup=("etc/$pkgname.toml")
 arch=("x86_64")
 license=("GPLv3+")
 makedepends=("cargo")
-optdepends=("ipmitool" "smartmontools")
+depends=("ipmitool")
+optdepends=("smartmontools")
 sha256sums=(
   "dc6fa88529fee2dacfe2b09fdeaa1e392c8a45e9821011231a60e76235a64d77"
-  "84fa667ae48ade2e8276c1abcfeea37428ccfa247544cb82c68f7c472b2897d7"
 )
 
 build() {
@@ -23,10 +23,18 @@ build() {
 }
 
 package() {
-  install -m755 -d "${pkgdir}/usr/lib/systemd/system/"
-  install -Dm644 ipmi-fan-control.service "${pkgdir}/usr/lib/systemd/system/"
-
   cd "$srcdir/$pkgname-$pkgver"
+
+  install -m755 -d "${pkgdir}/usr/lib/systemd/system/"
+
+  sed \
+      -e "s/@BINDIR@/\/usr\/bin/g" \
+      -e "s/@SYSCONFDIR@/\/etc/g" \
+      < dist/ipmi-fan-control.service \
+      > "${srcdir}"/ipmi-fan-control.service
+
+  install -Dm644 "${srcdir}"/ipmi-fan-control.service "${pkgdir}/usr/lib/systemd/system/"
+
   install -Dm755 "target/release/$pkgname" "${pkgdir}/usr/bin/$pkgname"
   install -Dm 644 config.sample.toml "${pkgdir}/etc/${pkgname}.toml"
 }


### PR DESCRIPTION
This adds PKGBUILD support to build_source_package.sh

```
./build_source_package.sh -t pkgbuild
cd output/pkg
makepkg -sc
```

produces
```
› tar -I zstd -tf ipmi-fan-control-v0.3.0.r0.gitd6e1761-1-x86_64.pkg.tar.zst
.BUILDINFO
etc/
etc/ipmi-fan-control.toml
.MTREE
.PKGINFO
usr/
usr/bin/
usr/bin/ipmi-fan-control
usr/lib/
usr/lib/systemd/
usr/lib/systemd/system/
usr/lib/systemd/system/ipmi-fan-control.service
```

I've confirmed the binary runs on my system using `ipmi-fan-control -V` and `ipmi-fan-control --help`

The only thing I've learned about packing on Debian is I hate packing on Debian so much :slightly_frowning_face: 