### PR TITLE
dist/pkgbuild/PKGBUILD.in: Remove PKGEXT workaround

### DIFF
--- a/dist/pkgbuild/PKGBUILD.in
+++ b/dist/pkgbuild/PKGBUILD.in
@@ -1,9 +1,5 @@
 # Maintainer: Christopher Hoage <iam@chrishoage.com>
 
-# Temporarily work around package signing issue with zstd-compressed packages
-# See: https://github.com/openSUSE/open-build-service/pull/10570
-PKGEXT='.pkg.tar.xz'
-
 pkgname=ipmi-fan-control
 pkgver=@VERSION@
 pkgrel=1


### PR DESCRIPTION
My upstream OBS fix for the issue that prevented `.tar.zst` Arch
packages from being signed has been deployed.

See: https://github.com/openSUSE/open-build-service/pull/10570

Signed-off-by: Andrew Gunnerson <chillermillerlong@hotmail.com>