### PR TITLE
dist/rpm/ipmi-fan-control.spec.in: Use %config(noreplace) for /etc/ipmi-fan-control.toml

### DIFF
--- a/dist/rpm/ipmi-fan-control.spec.in
+++ b/dist/rpm/ipmi-fan-control.spec.in
@@ -79,7 +79,7 @@ install -D -m 0644 config.sample.toml \
 %files
 %doc README.md
 %license LICENSE
-%config %{_sysconfdir}/%{name}.toml
+%config(noreplace) %{_sysconfdir}/%{name}.toml
 %{_bindir}/%{name}
 %{_unitdir}/%{name}.service
 


### PR DESCRIPTION
This fixes upgrades where the existing config is renamed to `/etc/ipmi-fan-control.toml.rpmsave` and the example config is used.