### PR TITLE
Improve logging: less verbosity by default; new config file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,35 +54,6 @@ sudo ./target/debug/ipmi-fan-control --config config.toml
 sudo ./target/release/ipmi-fan-control --config config.toml
 ```
 
-Logging
--------
-
-For tweaking the fan curve or troubleshooting issues, it may be helpful to increase the log level. To do so, set the `RUST_LOG` environment variable to one of the following values (from least verbose to most verbose):
-
-* `error`: Show fatal errors only
-* `warn`: Includes `error` and also shows recoverable errors
-* `info` (default): Includes `warn` and also shows fan mode changes on startup/shutdown
-* `debug`: Includes `info` and also shows status message with the temperature and duty cycle during each interval (useful for tuning the fan curve)
-* `trace`: Includes `debug` and also shows parsed values and the raw IPMI commands
-
-If ipmi-fan-control is being run directly, `RUST_LOG` can simply be set on the commmand line:
-
-```sh
-sudo RUST_LOG=<level> ipmi-fan-control <...>
-```
-
-Otherwise, if it's run via the systemd service, run:
-
-```sh
-sudo systemctl edit ipmi-fan-control
-```
-
-and add:
-
-```sh
-Enviroment=RUST_LOG=<level>
-```
-
 TODO
 ----
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,35 @@ sudo ./target/debug/ipmi-fan-control --config config.toml
 sudo ./target/release/ipmi-fan-control --config config.toml
 ```
 
+Logging
+-------
+
+For tweaking the fan curve or troubleshooting issues, it may be helpful to increase the log level. To do so, set the `RUST_LOG` environment variable to one of the following values (from least verbose to most verbose):
+
+* `error`: Show fatal errors only
+* `warn`: Includes `error` and also shows recoverable errors
+* `info` (default): Includes `warn` and also shows fan mode changes on startup/shutdown
+* `debug`: Includes `info` and also shows status message with the temperature and duty cycle during each interval (useful for tuning the fan curve)
+* `trace`: Includes `debug` and also shows parsed values and the raw IPMI commands
+
+If ipmi-fan-control is being run directly, `RUST_LOG` can simply be set on the commmand line:
+
+```sh
+sudo RUST_LOG=<level> ipmi-fan-control <...>
+```
+
+Otherwise, if it's run via the systemd service, run:
+
+```sh
+sudo systemctl edit ipmi-fan-control
+```
+
+and add:
+
+```sh
+Enviroment=RUST_LOG=<level>
+```
+
 TODO
 ----
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,3 +1,16 @@
+# Verbosity of the logging output. The valid log levels, from least verbose to
+# most verbose, are:
+#
+# * error: Fatal errors only
+# * warn:  Includes ^^ + recoverable errors
+# * info:  Includes ^^ + fan mode change messages on startup/shutdown
+# * debug: Includes ^^ + a status message with the temperature and duty cycle
+#          during each fan update interval (useful for tuning the fan curve)
+# * trace: Includes ^^ + details about parsed values and the raw IPMI commands
+#
+# (Note: This option is ignored if the RUST_LOG environment variable is set)
+#log_level = "info"
+
 # Definition of a logical fan zone.
 [[zones]]
 # IPMI session. If unspecified, the `default` session is used, which runs

--- a/dist/ipmi-fan-control.service.in
+++ b/dist/ipmi-fan-control.service.in
@@ -5,10 +5,8 @@ Description=SuperMicro IPMI fan control daemon
 ExecStart=@BINDIR@/ipmi-fan-control -c @SYSCONFDIR@/ipmi-fan-control.toml
 Restart=on-failure
 KillMode=process
-
-# The default logging level is info, but can be changed for more verbose status
-# messages or for troubleshooting.
-#Environment=RUST_LOG=info
+# Prevent logging timestamps since journald already has timestamps
+Environment=IPMI_FAN_CONTROL_LOG_TIMESTAMPS=false
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/ipmi-fan-control.service.in
+++ b/dist/ipmi-fan-control.service.in
@@ -6,5 +6,9 @@ ExecStart=@BINDIR@/ipmi-fan-control -c @SYSCONFDIR@/ipmi-fan-control.toml
 Restart=on-failure
 KillMode=process
 
+# The default logging level is info, but can be changed for more verbose status
+# messages or for troubleshooting.
+#Environment=RUST_LOG=info
+
 [Install]
 WantedBy=multi-user.target

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use {
     std::{
         collections::HashMap,
+        fmt,
         fs,
         path::Path,
         time::Duration,
@@ -9,6 +10,34 @@ use {
     serde::Deserialize,
     crate::error::{Error, Result},
 };
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Error => f.write_str("error"),
+            Self::Warn => f.write_str("warn"),
+            Self::Info => f.write_str("info"),
+            Self::Debug => f.write_str("debug"),
+            Self::Trace => f.write_str("trace"),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub struct Interval(pub u16);
@@ -126,6 +155,8 @@ pub struct Sessions(pub HashMap<String, Vec<String>>);
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    #[serde(default)]
+    pub log_level: LogLevel,
     #[serde(default)]
     pub sessions: Sessions,
     pub zones: Vec<Zone>,

--- a/src/ipmi.rs
+++ b/src/ipmi.rs
@@ -5,7 +5,7 @@ use {
         process::Command,
         result,
     },
-    log::debug,
+    log::trace,
     rexpect::{
         errors,
         session::{PtyReplSession, spawn_command},
@@ -203,7 +203,7 @@ impl Ipmi {
         S: AsRef<str>,
     {
         let command = Self::shell_quote(args)?;
-        debug!("Running IPMI command: {:?}", command);
+        trace!("Running IPMI command: {:?}", command);
 
         // Ensure we always wait for the prompt so that a failure does not
         // result in an output desync
@@ -287,7 +287,7 @@ impl Ipmi {
         args.extend(sensors.iter().map(|s| s.as_ref()));
 
         let command = Self::shell_quote(args)?;
-        debug!("Running IPMI command: {:?}", command);
+        trace!("Running IPMI command: {:?}", command);
 
         self.session.send_line(&command)
             .map_err(Error::SendCommand)?;
@@ -325,7 +325,7 @@ impl Ipmi {
                     .map_err(e!("Reading line not found"))?;
                 let (_, value) = self.session.exp_regex(r#"([\d\.]+|Not Available)"#)
                     .map_err(e!("Reading value not found"))?;
-                debug!("Sensor {:?} reading value: {:?}", sensor_name, value);
+                trace!("Sensor {:?} reading value: {:?}", sensor_name, value);
 
                 if value == "Not Available" {
                     return Err(Error::ReadingNotAvailable);
@@ -333,11 +333,11 @@ impl Ipmi {
 
                 let (_, tolerance) = self.session.exp_regex(r#"^\s+\(\+/-\s+[\d\.]+\)\s+"#)
                     .map_err(e!("Reading tolerance not found"))?;
-                debug!("Sensor {:?} reading tolerance: {:?}", sensor_name, tolerance);
+                trace!("Sensor {:?} reading tolerance: {:?}", sensor_name, tolerance);
 
                 let units = self.session.read_line()
                     .map_err(e!("Reading units not found"))?;
-                debug!("Sensor {:?} reading units: {:?}", sensor_name, units);
+                trace!("Sensor {:?} reading units: {:?}", sensor_name, units);
 
                 self.session.exp_regex(r#"\r?\n\r?\n"#)
                     .map_err(e!("End marker not found"))?;


### PR DESCRIPTION
This PR introduces two main changes. The first is to reduce the logging verbosity by default:

* Startup/shutdown messages remain at the `info` level
* Other `info` messages, like the status messages that are printed on each interval, are now logged at the `debug` level
* Messages related to implementation details, like the raw IPMI commands being executed, are now logged at the `trace` level

The second introduces a new `log_level` config file option to make it easier to change the log level than the `RUST_LOG` environment variable. (eg. `RUST_LOG=trace` will cause potentially unwanted trace messages of dependencies to be shown too.)

Also, when ipmi-fan-control is run via the systemd service, timestamps will no longer be logged since journald already has timestamps.

Fixes: #49 