### PR TITLE
dist/ipmi-fan-control.service.in: Enable most hardening options

### DIFF
--- a/dist/ipmi-fan-control.service.in
+++ b/dist/ipmi-fan-control.service.in
@@ -8,5 +8,30 @@ KillMode=process
 # Prevent logging timestamps since journald already has timestamps
 Environment=IPMI_FAN_CONTROL_LOG_TIMESTAMPS=false
 
+# Hardening
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateIPC=yes
+PrivateTmp=yes
+ProcSubset=pid
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+
+# Cannot be set because it prevents smartctl from gathering data
+#ProtectClock=yes
+
+# Network access is only needed for connecting to out-of-band IPMI devices.
+RestrictAddressFamilies=AF_INET AF_INET6
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
ipmi-fan-control doesn't do very much, so we can enable almost all of systemd's hardening options. The holes that need to be punched are for allowing:

* access to in-band IPMI devices
* access to IPv4/IPv6 sockets for remote sessions
* access to /sys for reading temperature sensor files
* execution of smartctl (and thus, access to disk devices)