### PR TITLE
.github/workflows: Remove Windows-related steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,9 @@ on:
 jobs:
   build:
     name: Build project
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
-    strategy:
-      fail-fast: false
-      matrix:
-        # Once Windows support is complete, windows-latest can be added
-        os: [ubuntu-22.04]
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,9 @@ jobs:
   build:
     name: Build project
     needs: create_release
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
-    strategy:
-      fail-fast: false
-      matrix:
-        # Once Windows support is complete, windows-latest can be added
-        os: [ubuntu-22.04]
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -76,29 +71,6 @@ jobs:
 
       - name: Build in release mode
         run: cargo build --release --verbose
-
-      - name: Build Windows archive
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          base_name=ipmi-fan-control-${{ needs.create_release.outputs.version }}-${{ steps.get_target.outputs.name }}
-          mkdir "${base_name}"
-          cp {README.md,LICENSE,config.sample.toml} "${base_name}/"
-
-          cp target/release/ipmi-fan-control.exe "${base_name}/"
-          7z a "${base_name}.zip" "${base_name}"
-          echo "ASSET=${base_name}.zip" >> "${GITHUB_ENV}"
-
-      - name: Upload Windows archive
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_name: ${{ env.ASSET }}
-          asset_path: ${{ env.ASSET }}
-          asset_content_type: application/octet-stream
 
   build_source_packages:
     name: Build source packages


### PR DESCRIPTION
This project does not and never has supported Windows. With the switch to libfreeipmi/libipmimonitoring, Windows support is now possible, but the project won't be providing official binaries.