### PR TITLE
Treat out-of-bounds temperature readings as errors

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -34,8 +34,7 @@ interval = 5
 # source fails. This field has no effect if `retries` is set to 0.
 #retry_delay_ms = 500
 
-# Temperature sources to use for measurement. Sensors that report invalid
-# temperatures are currently ignored.
+# Temperature sources to use for measurement.
 sources = [
     # IPMI sensor source. The sensor's units must be `degrees C`.
     { type = "ipmi", sensor = "CPU1 Temp" },

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,7 +209,7 @@ pub struct IpmitoolOpt {
 #[derive(Debug, Default)]
 pub struct SessionTypeCompat(pub SessionType);
 
-/// Deserialize either a map as a native SessionType instance or an array of
+/// Deserialize either a map as a native [`SessionType`] instance or an array of
 /// strings as ipmitool arguments.
 impl<'de> Deserialize<'de> for SessionTypeCompat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -312,7 +312,7 @@ pub fn load_config(path: &Path) -> Result<Config> {
         } else if zone_config.sources.is_empty() {
             return Err(Error::ConfigValidation {
                 path: path.to_owned(),
-                reason: format!("zones[{}].sensors: must be non-empty", i),
+                reason: format!("zones[{}].sources: must be non-empty", i),
             });
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,14 +45,16 @@ pub enum Error {
     },
     #[error("Sensor reading not available: {0}")]
     SensorNoReading(String),
-    #[error("Failed to parse SMART output for block device {block_dev:?}: {source}")]
+    #[error("Temperature reading out of bounds")]
+    ReadingExceedsBounds,
+    #[error("Failed to parse SMART output for block device: {block_dev:?}: {source}")]
     SmartParse {
         block_dev: PathBuf,
         source: serde_json::Error,
     },
-    #[error("No sensors had valid temperature readings")]
-    NoValidReadings,
-    #[error("Failed to run {command:?}: {status}")]
+    #[error("Block device has no temperature reading: {0:?}")]
+    SmartNoReading(PathBuf),
+    #[error("Failed to run: {command:?}: {status}")]
     Command {
         command: PathBuf,
         status: ExitStatus,


### PR DESCRIPTION
Previously, out-of-bounds temperature readings were ignored if multiple sources were configured and at least one of them reported a valid value. This could be dangerous since the user is not notified in any way that something might be wrong.