### PR TITLE
Add new hdparm source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This project depends on:
 * `pkg-config`
 * the Clang compiler (for generating Rust FFI bindings to the freeipmi libraries)
 * the Rust compiler
+* [optional] smartmontools (for querying HDD/SSD drive temperatures)
+* [optional] hdparm (for querying Hitachi/HGST/WD drive temperatures while spun down)
 
 These packages can be installed from the system package manager:
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -48,9 +48,18 @@ sources = [
     # The thermal_zone sysfs paths on Linux satisfy these conditions.
     { type = "file", path = "/sys/class/thermal/thermal_zone1/temp" },
 
-    # HDD S.M.A.R.T. source. Disks that are spun down are ignored to avoid
-    # unnecessary spin-ups. Requires smartmontools >= 7.0 to be installed.
+    # HDD S.M.A.R.T. source. Disks that are spun down may not report a
+    # temperature reading, leading to an error. This internally runs:
+    #
+    #   smartctl -j -A -n standby <block_dev>
+    #
+    # and requires smartmontools >= 7.0 to be installed.
     { type = "smart", block_dev = "/dev/disk/by-id/..." },
+
+    # "hdparm -H" source. This is specific to some Hitachi/HGST/WD drives and
+    # allows the HDD temperature to be queried even when the drive is spun down.
+    # This requires hdparm to be installed.
+    { type = "hdparm", block_dev = "/dev/disk/by-id/..." },
 ]
 
 # Method of aggregating the temperatures from all of the sources. By default,

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -29,6 +29,7 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends},
 Recommends:
+ hdparm,
  smartmontools (>= 7.0),
 Description: SuperMicro IPMI fan control daemon
  ipmi-fan-control is a program written in Rust to control the fans on SuperMicro

--- a/dist/pkgbuild/PKGBUILD.in
+++ b/dist/pkgbuild/PKGBUILD.in
@@ -11,7 +11,7 @@ arch=("x86_64")
 license=("GPLv3+")
 makedepends=("cargo" "clang")
 depends=("freeipmi")
-optdepends=("smartmontools")
+optdepends=("hdparm" "smartmontools")
 sha256sums=("@TARBALL_SHA256@")
 
 build() {

--- a/dist/rpm/ipmi-fan-control.spec.in
+++ b/dist/rpm/ipmi-fan-control.spec.in
@@ -34,9 +34,8 @@ BuildRequires:  systemd-rpm-macros
 %{systemd_requires}
 %endif
 
-%if 0%{?rhel} < 8
-Requires:       smartmontools >= 7.0
-%else
+%if 0%{?rhel} >= 8
+Recommends:     hdparm
 Recommends:     smartmontools >= 7.0
 %endif
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,10 @@ pub enum Source {
         // TOML can't encode OsString
         block_dev: String,
     },
+    Hdparm {
+        // TOML can't encode OsString
+        block_dev: String,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,10 @@ pub enum Error {
     },
     #[error("Block device has no temperature reading: {0:?}")]
     SmartNoReading(PathBuf),
+    #[error("hdparm reported no data: {0:?}")]
+    HdparmNoData(PathBuf),
+    #[error("hdparm reported bad data: {0:?}")]
+    HdparmBadData(PathBuf),
     #[error("Failed to run: {command:?}: {status}")]
     Command {
         command: PathBuf,


### PR DESCRIPTION
With version 0.4.0, ipmi-fan-control will no longer silently ignore missing or bad sensor readings. However, some drives do not report temperatures via SMART while in standby. This commit adds a new hdparm source that uses hdparm's -H option to send an OEM command for querying a Hitachi/HGST/WD drive's temperature, even when spun down.

Issue: #62