### PR TITLE
dist: Make config only readable by root

### DIFF
--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -16,6 +16,10 @@ override_dh_auto_clean:
 	cargo clean
 	rm -f debian/ipmi-fan-control.service
 
+override_dh_fixperms:
+	dh_fixperms --exclude ipmi-fan-control.toml
+	chmod 640 debian/ipmi-fan-control/etc/ipmi-fan-control.toml
+
 override_dh_installsystemd:
 	# The sample config must be edited for anything to work, so don't enable or
 	# start the service on the initial installation.

--- a/dist/pkgbuild/PKGBUILD.in
+++ b/dist/pkgbuild/PKGBUILD.in
@@ -34,5 +34,5 @@ package() {
   install -Dm644 "${srcdir}"/ipmi-fan-control.service "${pkgdir}/usr/lib/systemd/system/"
 
   install -Dm755 "target/release/$pkgname" "${pkgdir}/usr/bin/$pkgname"
-  install -Dm 644 config.sample.toml "${pkgdir}/etc/${pkgname}.toml"
+  install -Dm640 config.sample.toml "${pkgdir}/etc/${pkgname}.toml"
 }

--- a/dist/rpm/ipmi-fan-control.spec.in
+++ b/dist/rpm/ipmi-fan-control.spec.in
@@ -64,7 +64,7 @@ sed \
     < dist/ipmi-fan-control.service.in \
     > %{buildroot}%{_unitdir}/%{name}.service
 
-install -D -m 0644 config.sample.toml \
+install -D -m 0640 config.sample.toml \
     %{buildroot}%{_sysconfdir}/%{name}.toml
 
 %post


### PR DESCRIPTION
The config file will contain passwords if remote sessions are used.