### PR TITLE
dist/ipmi-fan-control.service.in: Start service after network-online.target

### DIFF
--- a/dist/ipmi-fan-control.service.in
+++ b/dist/ipmi-fan-control.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=SuperMicro IPMI fan control daemon
+After=network-online.target
 
 [Service]
 ExecStart=@BINDIR@/ipmi-fan-control -c @SYSCONFDIR@/ipmi-fan-control.toml


### PR DESCRIPTION
This is necessary when remote sessions are used. This is especially the case with 100Gbps NICs, like the Mellanox ConnectX-4, which takes more than a minute to establish a link during boot. ipmi-fan-control would fail to start and exhaust all of systemd's `on-failure` restarts.